### PR TITLE
Remove unnecessary legacy classes

### DIFF
--- a/src/patterns/error-validation/examples/error-summary/index.njk
+++ b/src/patterns/error-validation/examples/error-summary/index.njk
@@ -5,7 +5,7 @@
         type: "error"
     })
 %}
-<p class="mars">These <strong>must be corrected</strong> to continue.</p>
+<p>These <strong>must be corrected</strong> to continue.</p>
 {% from "components/list/src/_macro.njk" import onsList %}
 {{
     onsList({

--- a/src/patterns/error-validation/examples/errors-proto/errors/index.njk
+++ b/src/patterns/error-validation/examples/errors-proto/errors/index.njk
@@ -14,7 +14,7 @@
                             "classes": "u-mb-s"
                         })
                     %}
-                    <p class="mars">These <strong>must be corrected</strong> to continue.</p>
+                    <p>These <strong>must be corrected</strong> to continue.</p>
                     {% from "components/list/src/_macro.njk" import onsList %}
                     {{
                         onsList({


### PR DESCRIPTION
There were references to the mars font size in some of the templates, I've removed them as they're no longer necessary 