### PR TITLE
Fix indented markdown (from nunjucks renderer) from being wrapped in code blocks by removing indents

### DIFF
--- a/lib/nunjucks-html-loader.js
+++ b/lib/nunjucks-html-loader.js
@@ -6,7 +6,6 @@ import marked from 'marked';
 import pretty from 'pretty';
 import chalk from 'chalk';
 import { htmlErrorStack } from 'print-error';
-import stripIndent from 'strip-indent';
 
 import { MarkdownExtension } from './tags/markdown';
 import { NunjucksLoader } from './nunjucks-loader';

--- a/lib/nunjucks-html-loader.js
+++ b/lib/nunjucks-html-loader.js
@@ -6,6 +6,7 @@ import marked from 'marked';
 import pretty from 'pretty';
 import chalk from 'chalk';
 import { htmlErrorStack } from 'print-error';
+import stripIndent from 'strip-indent';
 
 import { MarkdownExtension } from './tags/markdown';
 import { NunjucksLoader } from './nunjucks-loader';
@@ -188,6 +189,9 @@ export default async function(source) {
 
   // Prettify HTML to stop markdown wrapping everything in code blocks
   html = pretty(html);
+
+  // Fix indented markdown (from nunjucks renderer) from being wrapped in code blocks by removing indents
+  html = html.replace(/\n\n\s*/g, '\n\n');
 
   // Render page markdown to HTML
   html = marked(html, {

--- a/webpack.dev.babel.js
+++ b/webpack.dev.babel.js
@@ -6,7 +6,7 @@ import chalk from 'chalk';
 
 import commonConfig from './webpack.common';
 
-const port = 3001;
+const port = process.env.PATTERN_LIB_PORT || 3010;
 const common = commonConfig('development');
 
 function getIP() {


### PR DESCRIPTION
Nunjucks loader is run first and will add indentation to markdown which then the markdown renderer will wrap in code blocks. This uses a regex replacement to remove the indentation before the markdown to html renderer is run.

Resolves #17 