### PR TITLE
Fix indented markdown (from nunjucks renderer) from being wrapped in code blocks by removing indents

### DIFF
--- a/lib/nunjucks-html-loader.js
+++ b/lib/nunjucks-html-loader.js
@@ -190,7 +190,7 @@ export default async function(source) {
   html = pretty(html);
 
   // Fix indented markdown (from nunjucks renderer) from being wrapped in code blocks by removing indents
-  html = html.replace(/\n\n\s*/g, '\n\n');
+  html = html.replace(/(\n +)/g, '\n');
 
   // Render page markdown to HTML
   html = marked(html, {


### PR DESCRIPTION
Resolves #17 