### PR TITLE
Fix nunjucks-html-loader handling of `code` tags

### DIFF
--- a/lib/nunjucks-html-loader.js
+++ b/lib/nunjucks-html-loader.js
@@ -190,7 +190,7 @@ export default async function(source) {
   html = pretty(html);
 
   // Fix indented markdown (from nunjucks renderer) from being wrapped in code blocks by removing indents
-  html = html.replace(/(\n +)/g, '\n');
+  html = html.replace(/(?!<code[^>]*?>)(\n +)(?![^<]*?<\/code>)/g, '\n');
 
   // Render page markdown to HTML
   html = marked(html, {


### PR DESCRIPTION
Update preceding whitespace preceding whitespace renderer to only remove preceding whitespace (caused by nunjucks renderer) from text not wrapped in `code` tags, to prevent markdown renderer from wrapping it in `code` tags.

Resolves #27 