### PR TITLE
Fix automatic package.json version updating

### DIFF
--- a/.travis/pu.sh
+++ b/.travis/pu.sh
@@ -30,7 +30,7 @@ make_version() {
   git checkout master
 
   # %s is the placeholder for the created tag
-  npm version $TRAVIS_BRANCH -m --allow-same-version "chore - release version %s [skip ci]" --allow-empty
+  npm version $TRAVIS_BRANCH --allow-same-version -m "chore - release version %s [skip ci]" --allow-empty
 
   git push origin master
 }


### PR DESCRIPTION
I accidentally broke the automatic package.json version updating just before I merge the npm bundle creator branch. This should fix that functionality.